### PR TITLE
Add Dockerfile and scripts to extend support for the Intel OpenCL TornadoVM image

### DIFF
--- a/Dockerfile-intel-igpu
+++ b/Dockerfile-intel-igpu
@@ -1,0 +1,57 @@
+FROM intelopencl/intel-opencl:ubuntu-18.04-ppa
+
+LABEL MAINTAINER Juan Fumero <juan.fumero@manchester.ac.uk>
+
+RUN apt-get update
+RUN apt-get install vim git cmake -y
+RUN apt-get install maven -y
+RUN apt-get install openjdk-8-jdk -y 
+
+COPY settings_intel.xml /root/.m2/settings.xml
+
+RUN java -version
+RUN javac -version
+
+## Install Python
+RUN apt-get update -q && apt-get install -qy \
+    python-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PATH /usr/lib/jvm/java-8-openjdk-amd64/bin:$PATH
+
+## Compile JVMCI with Tornado patch
+WORKDIR /tornado
+RUN git clone -b tornado https://github.com/beehive-lab/mx 
+ENV PATH /tornado/mx:$PATH 
+RUN git clone -b tornado https://github.com/beehive-lab/graal-jvmci-8
+WORKDIR /tornado/graal-jvmci-8
+RUN echo "JAVA_HOME=/usr/lib/jvm/java-8-oracle/jre/bin/java" >> /tornado/graal-jvmci-8/mx.jvmci/env
+RUN cat /tornado/graal-jvmci-8/mx.jvmci/env
+RUN mx build -p; exit 0 ### XXX 
+RUN mx build -p 
+
+## Compile Tornado
+WORKDIR /tornado
+RUN git clone https://github.com/beehive-lab/TornadoVM.git tornado
+ENV JAVA_HOME /tornado/graal-jvmci-8/jdk1.8.0_212/product
+ENV PATH /tornado/tornado/bin/bin:$PATH
+ENV PATH /usr/lib/jvm/java-8-oracle/bin:$PATH
+ENV TORNADO_SDK /tornado/tornado/bin/sdk
+WORKDIR /tornado/tornado
+RUN apt-get update && apt-get install -y opencl-headers
+RUN ln -s /usr/lib/x86_64-linux-gnu/libOpenCL.so.1 /usr/lib/x86_64-linux-gnu/libOpenCL.so
+ENV OpenCL_LIBRARY /usr/lib/x86_64-linux-gnu/libOpenCL.so.1
+RUN mvn package
+
+RUN cd /tornado/tornado/bin && ln -s /tornado/tornado/dist/tornado-sdk/tornado-sdk-*/bin/ bin
+RUN cd /tornado/tornado/bin && ln -s /tornado/tornado/dist/tornado-sdk/tornado-sdk-*/ sdk
+
+# Tornado ENV-Variables
+ENV PATH /tornado/tornado/bin/bin:$PATH
+ENV PATH /tornado/graal-jvmci-8/jdk1.8.0_212/product/bin:$PATH
+ENV TORNADO_SDK /tornado/tornado/bin/sdk 
+
+WORKDIR /data
+VOLUME ["/data"]
+
+RUN echo "Tornado BUILD done"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Docker for Tornado-GPU
 
 
-![](https://img.shields.io/docker/pulls/beehivelab/tornado-gpu.svg)  [![](https://img.shields.io/badge/License-Apache%202.0-orange.svg)](https://opensource.org/licenses/Apache-2.0)
+![](https://img.shields.io/docker/pulls/beehivelab/tornado-gpu.svg?color=green&label=docker%20pulls%20nvidia)  [![](https://img.shields.io/badge/License-Apache%202.0-orange.svg)](https://opensource.org/licenses/Apache-2.0)
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ $ docker pull beehivelab/tornado-gpu:latest
 
 We provide a runner script that compiles and run your Java programs with Tornado. Here's an example:
 
-[in the case of `intel-gpu` image use the `run_intel.sh` script instead]
-
 ```bash
 $ git clone https://github.com/beehive-lab/docker-tornado
 $ cd docker-tornado
@@ -64,7 +62,7 @@ $ ./run.sh tornado -Xmx16g -Xms16g example/MatrixMultiplication
 
 ### Prerequisites
 
-The `tornado-intel-gpu` docker image needs the docker `intel-opencl` daemon.  More info here: [https://github.com/intel/compute-runtime](https://github.com/intel/compute-runtime).
+The `tornado-intel-gpu` docker image Intel OpenCL driver for the integrated GPU installed.  More info here: [https://github.com/intel/compute-runtime](https://github.com/intel/compute-runtime).
 
 ### How to run?
 
@@ -93,8 +91,6 @@ Computing MxM of 256x256
 	Speedup: 5x
 
 ```
-
-
 
 
 Enjoy Tornado!! 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # Docker for Tornado-GPU
 
 
-![](https://img.shields.io/docker/pulls/beehivelab/tornado-gpu.svg?color=green&label=docker%20pulls%20nvidia)  [![](https://img.shields.io/badge/License-Apache%202.0-orange.svg)](https://opensource.org/licenses/Apache-2.0)
+![](https://img.shields.io/docker/pulls/beehivelab/tornado-gpu.svg?color=green&label=docker%20pulls%20nvidia)  ![](https://img.shields.io/docker/pulls/beehivelab/tornado-intel-gpu.svg?color=purple&label=docker%20pulls%20intel)  [![](https://img.shields.io/badge/License-Apache%202.0-orange.svg)](https://opensource.org/licenses/Apache-2.0)
 
 ## Prerequisites
 
-The `tornado-gpu` docker image needs the docker `nvidia` daemon. 
+* The `tornado-gpu` docker image needs the docker `nvidia` daemon. 
 More info here: [https://github.com/NVIDIA/nvidia-docker](https://github.com/NVIDIA/nvidia-docker).
+
+* The `tornado-intel-gpu` docker image needs the docker `intel-opencl` daemon. 
+More info here: [https://github.com/intel/compute-runtime](https://github.com/intel/compute-runtime).
 
 ## How to run?
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,20 @@ More info here: [https://github.com/intel/compute-runtime](https://github.com/in
 
 1) Pull the image
 
+* For the `nvidia` image:
 ```bash
 $ docker pull beehivelab/tornado-gpu:latest
+```
+* For the `intel-gpu` image:
+```bash
+$ docker pull beehivelab/tornado-intel-gpu:latest
 ```
 
 2) Run an experiment
 
-We provide a runner script that compiles and run your Java programs with Tornado. Here's an example: 
+We provide a runner script that compiles and run your Java programs with Tornado. Here's an example:
+
+[in the case of `intel-gpu` image use the `run_intel.sh` script instead]
 
 ```bash
 $ git clone https://github.com/beehive-lab/docker-tornado

--- a/README.md
+++ b/README.md
@@ -1,27 +1,20 @@
-# Docker for Tornado-GPU
-
+# Docker for TornadoVM
 
 ![](https://img.shields.io/docker/pulls/beehivelab/tornado-gpu.svg?color=green&label=docker%20pulls%20nvidia)  ![](https://img.shields.io/docker/pulls/beehivelab/tornado-intel-gpu.svg?color=purple&label=docker%20pulls%20intel)  [![](https://img.shields.io/badge/License-Apache%202.0-orange.svg)](https://opensource.org/licenses/Apache-2.0)
 
+# Nvidia GPUs
 ## Prerequisites
 
-* The `tornado-gpu` docker image needs the docker `nvidia` daemon. 
+The `tornado-gpu` docker image needs the docker `nvidia` daemon. 
 More info here: [https://github.com/NVIDIA/nvidia-docker](https://github.com/NVIDIA/nvidia-docker).
-
-* The `tornado-intel-gpu` docker image needs the docker `intel-opencl` daemon. 
-More info here: [https://github.com/intel/compute-runtime](https://github.com/intel/compute-runtime).
 
 ## How to run?
 
 1) Pull the image
 
-* For the `nvidia` image:
+For the `nvidia` image:
 ```bash
 $ docker pull beehivelab/tornado-gpu:latest
-```
-* For the `intel-gpu` image:
-```bash
-$ docker pull beehivelab/tornado-intel-gpu:latest
 ```
 
 2) Run an experiment
@@ -60,6 +53,44 @@ The `tornado` command is just an alias to the `java` command with all the parame
 ```bash
 $ ./run.sh tornado -Xmx16g -Xms16g example/MatrixMultiplication
 ```
+
+# Intel Intergrated GPUs
+## Prerequisites
+
+The `tornado-intel-gpu` docker image needs the docker `intel-opencl` daemon. 
+More info here: [https://github.com/intel/compute-runtime](https://github.com/intel/compute-runtime).
+
+## How to run?
+
+1) Pull the image
+
+For the `intel-gpu` image:
+```bash
+$ docker pull beehivelab/tornado-intel-gpu:latest
+```
+2) Run an experiment
+
+We provide a runner script that compiles and run your Java programs with Tornado. Here's an example:
+
+```bash
+$ git clone https://github.com/beehive-lab/docker-tornado
+$ cd docker-tornado
+
+## Compile Matrix Multiplication - provided in the docker-tornado repository
+$ ./run_intel.sh javac.py example/MatrixMultiplication.java
+
+## Run with TornadoVM on the NVIDIA GPU !
+$ ./run_intel.sh tornado example/MatrixMultiplication 2048   ## Running on Intel(R) Gen9 HD Graphics
+Computing MxM of 256x256
+	CPU Execution: 1.53 GFlops, Total time = 22 ms
+	GPU Execution: 8.39 GFlops, Total Time = 4 ms
+	Speedup: 5x
+
+```
+
+
+
+
 
 Enjoy Tornado!! 
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,20 @@
 # Docker for TornadoVM
 
-![](https://img.shields.io/docker/pulls/beehivelab/tornado-gpu.svg?color=green&label=docker%20pulls%20nvidia)  ![](https://img.shields.io/docker/pulls/beehivelab/tornado-intel-gpu.svg?color=purple&label=docker%20pulls%20intel)  [![](https://img.shields.io/badge/License-Apache%202.0-orange.svg)](https://opensource.org/licenses/Apache-2.0)
+![](https://img.shields.io/docker/pulls/beehivelab/tornado-gpu.svg?color=green&label=docker%20pulls%20nvidia)  ![](https://img.shields.io/docker/pulls/beehivelab/tornado-intel-gpu.svg?color=blue&label=docker%20pulls%20intel)  [![](https://img.shields.io/badge/License-Apache%202.0-orange.svg)](https://opensource.org/licenses/Apache-2.0)
 
-# Nvidia GPUs
-## Prerequisites
+We have two docker configurations for TornadoVM:
 
-The `tornado-gpu` docker image needs the docker `nvidia` daemon. 
-More info here: [https://github.com/NVIDIA/nvidia-docker](https://github.com/NVIDIA/nvidia-docker).
+* TornadoVM Docker for NVIDIA GPUs: See [instructions](https://github.com/beehive-lab/docker-tornado#Nvidia)
+* TornadoVM Docker for Intel Integrated Graphics: See [instructions](https://github.com/beehive-lab/docker-tornado#Intel)
 
-## How to run?
+
+## Nvidia GPUs
+
+### Prerequisites
+
+The `tornado-gpu` docker image needs the docker `nvidia` daemon.  More info here: [https://github.com/NVIDIA/nvidia-docker](https://github.com/NVIDIA/nvidia-docker).
+
+### How to run?
 
 1) Pull the image
 
@@ -54,13 +60,13 @@ The `tornado` command is just an alias to the `java` command with all the parame
 $ ./run.sh tornado -Xmx16g -Xms16g example/MatrixMultiplication
 ```
 
-# Intel Intergrated GPUs
-## Prerequisites
+## Intel Intergrated GPUs
 
-The `tornado-intel-gpu` docker image needs the docker `intel-opencl` daemon. 
-More info here: [https://github.com/intel/compute-runtime](https://github.com/intel/compute-runtime).
+### Prerequisites
 
-## How to run?
+The `tornado-intel-gpu` docker image needs the docker `intel-opencl` daemon.  More info here: [https://github.com/intel/compute-runtime](https://github.com/intel/compute-runtime).
+
+### How to run?
 
 1) Pull the image
 
@@ -87,7 +93,6 @@ Computing MxM of 256x256
 	Speedup: 5x
 
 ```
-
 
 
 

--- a/build_intel_igpu.sh
+++ b/build_intel_igpu.sh
@@ -3,7 +3,7 @@
 IMAGE=tornado-intel-igpu
 docker build --cpuset-cpus="0-7" -t $IMAGE -f Dockerfile-intel-igpu .
 
-TAG=dev
-docker tag tornado-intel-igpu beehivelab/tornado-gpu:$TAG
+TAG=latest
+docker tag tornado-intel-igpu beehivelab/tornado-intel-gpu:$TAG
 
 

--- a/build_intel_igpu.sh
+++ b/build_intel_igpu.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+IMAGE=tornado-intel-igpu
+docker build --cpuset-cpus="0-7" -t $IMAGE -f Dockerfile-intel-igpu .
+
+TAG=dev
+docker tag tornado-intel-igpu beehivelab/tornado-gpu:$TAG
+
+

--- a/run_intel.sh
+++ b/run_intel.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+IMAGE=tornado-intel-igpu:latest
+exec docker run -it --device /dev/dri:/dev/dri --rm -v $PWD:/example -w /example "$IMAGE" "$@"
+

--- a/run_intel.sh
+++ b/run_intel.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-IMAGE=tornado-intel-igpu:latest
+IMAGE=beehivelab/tornado-intel-gpu:latest
 exec docker run -it --device /dev/dri:/dev/dri --rm -v $PWD:/example -w /example "$IMAGE" "$@"
 

--- a/settings_intel.xml
+++ b/settings_intel.xml
@@ -1,0 +1,28 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+	https://maven.apache.org/xsd/settings-1.0.0.xsd">
+ <interactiveMode/>
+ <usePluginRegistry/>
+ 	<offline/>
+		 <pluginGroups/>
+	 <servers/>
+ 	<mirrors/>
+	 <proxies/>
+	 <profiles>
+	 <profile>
+		 <id>tornado-jvmci</id>
+		 <activation>
+		 <activeByDefault>true</activeByDefault>
+		 </activation>
+		 <properties>
+			 <!-- Your PATH TO JDK1.8-JVMCI-->
+			 <jvmci.root>/tornado/graal-jvmci-8/jdk1.8.0_212/product</jvmci.root>
+			 <!-- Your JDK1.8-JVMCI version-->
+		 	 <jvmci.version>1.8.0_212</jvmci.version>
+		 </properties>
+	 </profile>
+	 </profiles>
+	 <activeProfiles/>
+</settings>
+


### PR DESCRIPTION
This PR contains a set of build, run and Dockerfiles to enable support for Intel OpenCL docker image.